### PR TITLE
added css rule to remove borders from imgs

### DIFF
--- a/resource/css/presentation.css
+++ b/resource/css/presentation.css
@@ -58,3 +58,7 @@ figure img, figure video {
 h1, h2, h3, h4, h5, h6 {
   text-transform: none !important;
 }
+.reveal section img.withoutBorder {
+  border:none;
+  box-shadow:none;
+}


### PR DESCRIPTION
Think you'd like this for your presentations. Now, when you add a `class="withoutBorder"` to an `<img/>`, you'd remove the styling added by reveal